### PR TITLE
To avoid error, type check is added.

### DIFF
--- a/nlib.py
+++ b/nlib.py
@@ -1073,7 +1073,8 @@ def fit_least_squares(points, f):
     chi = A*c-b
     chi2 = norm(chi,2)**2
     fitting_f = lambda x, c=c, f=f, q=eval_fitting_function: q(f,c,x)
-    return c.flatten(), chi2, fitting_f
+    if isinstance(c,Matrix): return c.flatten(), chi2, fitting_f
+    else: return c, chi2, fitting_f
 
 # examples of fitting functions
 def POLYNOMIAL(n):


### PR DESCRIPTION
c will be a float if the result of (1.0/(A.T*A))*(A.T*b) is a 1x1 matrix according to Matrix.__mul__ .

When I'm doing my final project of CSC431 I find this bug. For details run the attached code.

[final_project.txt](https://github.com/mdipierro/nlib/files/181121/final_project.txt)
