### PR TITLE
Removed repetitive section on range in 2.3.1

### DIFF
--- a/docs/book_numerical.tex
+++ b/docs/book_numerical.tex
@@ -1018,8 +1018,6 @@ Another useful command is {\ft enumerate}, which counts while looping and return
 3 python
 \end{lstlisting}
 
-There is also a keyword {\ft range(a, b, c)} that returns a list of integers starting with the value {\ft a}, incrementing by {\ft c}, and ending with the last value smaller than {\ft b}, where {\ft a} defaults to 0 and {\ft c} defaults to 1.
-
 You can jump out of a loop using {\ft break}:
 %%% META:FILE:test.py
 \begin{lstlisting}


### PR DESCRIPTION
Seems like this sentence was left in accidentally, considering there is a more in depth discussion earlier.