### PR TITLE
Remove repetitive isinf() description in 2.6.1

### DIFF
--- a/docs/book_numerical.tex
+++ b/docs/book_numerical.tex
@@ -1637,8 +1637,6 @@ Here is a sampling of some of the methods available in the {\ft math} and {\ft c
 \item {\ft math.cos(x)},{\ft math.sin(x)},{\ft math.tan(x)} returns the cos, sin, tan of the value of {\ft x};  {\ft x} is in radians
 
 \item {\ft math.pi}, {\ft math.e} are the constants for {\ft pi} and {\ft e} to available precision
-
-\item {\ft math.isinf(x)} can be used to check if a number is {\it infinity}.
 \end{itemize}
 
 


### PR DESCRIPTION
Found another one, math.isinf() is described better above.